### PR TITLE
add pageId option to #index

### DIFF
--- a/src/blog.coffee
+++ b/src/blog.coffee
@@ -167,15 +167,19 @@ class Blog
   # GET CollectionURI (/<username>/<blog_id>/atom/entry)
   # params:
   #   options:
+  #   - pageId: page id.
   #   callback:
   #   - err: error
   #   - res: response
   # returns:
   #   Promise
   index: (options, callback) ->
-    callback = options unless callback?
     method = 'get'
-    path = "/#{@_username}/#{@_blogId}/atom/entry"
+    if options? and options.pageId?
+        path = "/#{@_username}/#{@_blogId}/atom/entry?page=#{options.pageId}"
+    else
+        callback = options unless callback?
+        path = "/#{@_username}/#{@_blogId}/atom/entry"
     statusCode = 200
     @_request { method, path, statusCode }, callback
 

--- a/test/blog.coffee
+++ b/test/blog.coffee
@@ -196,19 +196,19 @@ describe 'blog', ->
         blogId: 'blog id'
         apiKey: 'api key'
 
-    describe 'all options', ->
+    describe 'no options', ->
       it 'works', ->
         @blog.index {}, -> null
         args = @request.firstCall.args[0]
         assert args.method is 'get'
         assert args.path is '/username/blog id/atom/entry'
 
-    describe 'callback only', ->
+    describe 'pageId options', ->
       it 'works', ->
-        @blog.index -> null
+        @blog.index { pageId: 123 }, -> null
         args = @request.firstCall.args[0]
         assert args.method is 'get'
-        assert args.path is '/username/blog id/atom/entry'
+        assert args.path is '/username/blog id/atom/entry?page=123'
 
   describe '_request', ->
     describe 'request succeed', ->


### PR DESCRIPTION
Added pageId option to `index` method.  We can now get entry lists except for the first list.
