### PR TITLE
Add categories field to BlogEntry type

### DIFF
--- a/src/blog-type.ts
+++ b/src/blog-type.ts
@@ -10,6 +10,7 @@ interface Blog {
 
 interface BlogEntry {
   authorName: string;
+  categories: string[];
   content: string;
   contentType: BlogEntryContentType;
   draft: boolean;

--- a/src/xml.ts
+++ b/src/xml.ts
@@ -54,6 +54,8 @@ const getEntry = (entry: Element): BlogEntry => {
 
   const authorName = getElementTextByTagNames(entry, ['author', 'name']);
 
+  const categories = getElementsByTagName(entry, 'category').map((category) => category.attributes.term);
+
   const contentElement = getElementByTagNames(entry, ['content']);
   if (contentElement === null) throw new Error('no content');
   if (contentElement.children.length === 0 || (
@@ -96,6 +98,7 @@ const getEntry = (entry: Element): BlogEntry => {
 
   return {
     authorName,
+    categories,
     content,
     contentType,
     draft,


### PR DESCRIPTION
We can include `categories` when creating `BlogEntry`, but we can't get `categories` when we retrieving `BlogEntry`.

I added `categories` filed to `BlogEntry` type.